### PR TITLE
ci: add semantic release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,65 @@
 name: "Release"
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+    inputs:
+      dryRun:
+        description: "Do a dry run to preview instead of a real release [true/false]"
+        required: true
+        default: "false"
 
 jobs:
+  semantic-release:
+    name: "Semantic Release"
+    runs-on: macos-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.MP_SEMANTIC_RELEASE_BOT }}
+      GIT_AUTHOR_NAME: mparticle-bot
+      GIT_AUTHOR_EMAIL: developers@mparticle.com
+      GIT_COMMITTER_NAME: mparticle-bot
+      GIT_COMMITTER_EMAIL: developers@mparticle.com
+    steps:
+      - name: "Checkout public main branch"
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          ref: main
+      - name: "Import GPG Key"
+        uses: crazy-max/ghaction-import-gpg@v4
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+      - name: "Semantic Release --dry-run"
+        if: ${{ github.event.inputs.dryRun == 'true' }}
+        run: |
+          npx \
+          -p lodash \
+          -p semantic-release@17 \
+          -p @semantic-release/changelog@5 \
+          -p @semantic-release/git@9 \
+          -p @semantic-release/exec@5 \
+          semantic-release --dry-run
+      - name: "Semantic Release"
+        if: ${{ github.event.inputs.dryRun == 'false' }}
+        run: |
+          npx \
+          -p lodash \
+          -p semantic-release@17 \
+          -p @semantic-release/changelog@5 \
+          -p @semantic-release/git@9 \
+          -p @semantic-release/exec@5 \
+          semantic-release
+      - name: "Push automated release commits to release branch"
+        if: ${{ github.event.inputs.dryRun == 'false' }}
+        run: |
+          git push origin main
+
   sonatype-release:
     name: "Github Packages Release"
+    needs: semantic-release
     runs-on: macos-latest
+    if: ${{ github.event.inputs.dryRun == 'false' }}
     env:
       githubUsername: mparticle-bot
       githubToken: ${{ secrets.GITHUB_TOKEN }}
@@ -12,6 +67,7 @@ jobs:
       - name: "Checkout"
         uses: actions/checkout@v2
         with:
+          ref: main
           submodules: recursive
       - name: "Install JDK 11"
         uses: actions/setup-java@v2

--- a/.scripts/release.sh
+++ b/.scripts/release.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+: ${1?"Version missing - usage: $0 x.y.z"}
+
+#update build.gradle
+sed -i '.bak' "s/version=.*/version=$1/g" gradle.properties
+
+#update README.md
+sed -i '.bak' "s/\"com.mparticle:api:.*\"/\"com.mparticle:api:$1\"/g" README.md
+sed -i '.bak' "s/\"com.mparticle:models:.*\"/\"com.mparticle:models:$1\"/g" README.md
+sed -i '.bak' "s/\"com.mparticle:testing:.*\"/\"com.mparticle:testing:$1\"/g" README.md
+
+#commit the version bump, tag, and push to private and public
+git add gradle.properties
+git add README.md

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ repositories {
 
 dependencies {
     ...
-    implementation("com.mparticle:models:0.1")              // <--- add for serializable server DTOs
+    implementation("com.mparticle:models:2.3")              // <--- add for serializable server DTOs
     ...
-    androidTestImplementation("com.mparticle:testing:0.1")  // <--- add for `Server` and instrumented testing base classes
+    androidTestImplementation("com.mparticle:testing:2.3")  // <--- add for `Server` and instrumented testing base classes
  }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,4 +10,4 @@ xcodeproj=Tests/helpers/XCodeTest
 kotlin.mpp.stability.nowarn=true
 
 group=com.mparticle
-version=0.1
+version=2.3

--- a/release.config.js
+++ b/release.config.js
@@ -1,0 +1,51 @@
+module.exports = {
+  branches: ["main"],
+  tagFormat: "v${version}",
+  plugins: [
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        preset: "angular",
+        releaseRules: [
+            {type: 'feat', release: 'minor'},
+            {type: 'ci', release: 'patch'},
+            {type: 'fix', release: 'patch'},
+            {type: 'docs', release: 'patch'},
+            {type: 'test', release: 'patch'},
+            {type: 'refactor', release: 'patch'},
+            {type: 'style', release: 'patch'},
+            {type: 'build', release: 'patch'},
+            {type: 'chore', release: 'patch'},
+            {type: 'revert', release: 'patch'}
+       ]
+      }
+    ],
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        preset: "angular",
+      },
+    ],
+    [
+      "@semantic-release/changelog",
+      {
+        changelogFile: "CHANGELOG.md",
+      },
+    ],
+    [
+      "@semantic-release/exec",
+      {
+        prepareCmd: "sh ./.scripts/release.sh ${nextRelease.version}",
+      },
+    ],
+    ["@semantic-release/github"],
+    [
+      "@semantic-release/git",
+      {
+        assets: ["CHANGELOG.md", "gradle.properties", "README.md"],
+        message:
+          "chore(release): ${nextRelease.version} \n\n${nextRelease.notes}",
+      },
+    ],
+  ],
+};


### PR DESCRIPTION
# Summary

Add semantic release as a part of the release task. I migrated the script from android-core, so version number will automatically update in the README and build.gradle
