### PR TITLE
feat: add Sonatype (mavenCentral) publication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,13 +56,15 @@ jobs:
           git push origin main
 
   sonatype-release:
-    name: "Github Packages Release"
+    name: "Sonatype (Maven Central) Release"
     needs: semantic-release
     runs-on: macos-latest
     if: ${{ github.event.inputs.dryRun == 'false' }}
     env:
-      githubUsername: mparticle-bot
-      githubToken: ${{ secrets.GITHUB_TOKEN }}
+      sonatypeUsername: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
+      sonatypePassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
+      mavenSigningKeyId: ${{ secrets.MAVEN_CENTRAL_SIGNING_KEY }}
+      mavenSigningKeyPassword: ${{ secrets.MAVEN_CENTRAL_SIGNING_KEY_PASSWORD }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v2
@@ -76,6 +78,6 @@ jobs:
           java-version: "11"
       - name: Install Cocoapods
         run: sudo gem install cocoapods; sudo gem install cocoapods-generate
-      - name: "Publish Android To Github Repo"
+      - name: "Publish Android To Sonatype"
         run: |
-          ./gradlew publishAndroidDebugPublicationToGithubRepository
+          ./gradlew publishReleasePublicationToMavenCentralRepository

--- a/.scripts/maven.gradle
+++ b/.scripts/maven.gradle
@@ -1,0 +1,76 @@
+apply plugin: "maven-publish"
+apply plugin: "signing"
+
+publishing {
+    publications {
+        try {
+            androidDebug {
+                artifactId = project.name
+            }
+        } catch (ignored) {}
+        release(MavenPublication) {
+            groupId = project.group
+            artifactId = project.name
+
+            project.tasks.findByName("generateJavadocsJar")?.let {
+                artifact(it)
+            }
+            project.tasks.findByName("generateSourcesJar")?.let {
+                artifact(it)
+            }
+
+            pom {
+                name.set(project.name)
+                description.set(project.name)
+                url.set("https://github.com/mParticle/crossplatform-sdk-tests")
+                licenses {
+                    license {
+                        name.set("The Apache Software License, Version 2.0")
+                        url.set("https://www.apache.org/license/LICENSE-2.0.txt")
+                    }
+                }
+                developers {
+                    developer {
+                        id.set("mParticle")
+                        name.set("mParticle Inc.")
+                        email.set("developers@mparticle.com")
+                    }
+                }
+                scm {
+                    url.set("https://github.com/mParticle/crossplatform-sdk-tests")
+                    connection.set("scm:git:https://github.com/mparticle/crossplatform-sdk-tests")
+                    developerConnection.set("scm:git:git@github.com:mparticle/crossplatform-sdk-tests.git")
+                }
+            }
+        }
+    }
+    repositories {
+        maven {
+            name = "github"
+            setUrl("https://maven.pkg.github.com/mParticle/crossplatform-sdk-tests")
+            credentials {
+                username = System.getenv("githubUsername")
+                password = System.getenv("githubToken")
+            }
+        }
+        maven {
+            name = "mavenCentral"
+            setUrl("https://oss.sonatype.org/service/local/staging/deploy/maven2/")
+            credentials {
+                username = System.getenv("sonatypeUsername")
+                password = System.getenv("sonatypePassword")
+            }
+        }
+    }
+}
+
+
+signing {
+    def signingKey = System.getenv("mavenSigningKeyId")
+    def signingPassword = System.getenv("mavenSigningKeyPassword")
+    gradle.taskGraph.whenReady {
+        required = it.hasTask("publishReleasePublicationToMavenRepository")
+    }
+    useInMemoryPgpKeys(signingKey, signingPassword)
+    sign(publishing.publications["release"])
+}

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -8,13 +8,13 @@ plugins {
     kotlin("multiplatform")
     kotlin("plugin.serialization")
     kotlin("native.cocoapods")
-    id("maven-publish")
 }
+apply(from = "../.scripts/maven.gradle")
 
 kotlin {
 
     android {
-        publishLibraryVariants("debug")
+        publishLibraryVariants("release")
         mavenPublication {
             artifactId = project.name
         }
@@ -86,17 +86,4 @@ android {
 }
 dependencies {
     implementation("androidx.lifecycle:lifecycle-common:2.2.0")
-}
-
-publishing {
-    repositories {
-        maven {
-            name = "github"
-            setUrl("https://maven.pkg.github.com/mParticle/crossplatform-sdk-tests")
-            credentials {
-                username = System.getenv("githubUsername")
-                password = System.getenv("githubToken")
-            }
-        }
-    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,5 +9,5 @@ kotlin.native.cacheKind=none
 xcodeproj=Tests/helpers/XCodeTest
 kotlin.mpp.stability.nowarn=true
 
-group=com.mparticle
+group=com.mparticle.internal
 version=1.0.0

--- a/models/build.gradle.kts
+++ b/models/build.gradle.kts
@@ -7,8 +7,9 @@ plugins {
     kotlin("multiplatform")
     kotlin("plugin.serialization")
     kotlin("native.cocoapods")
-    id("maven-publish")
 }
+apply(from = "../.scripts/maven.gradle")
+
 
 repositories {
     mavenLocal()
@@ -18,7 +19,7 @@ val xcFramework = XCFramework()
 
 kotlin {
     android {
-        publishLibraryVariants("debug")
+        publishLibraryVariants("release")
         mavenPublication {
             artifactId = project.name
         }
@@ -68,18 +69,5 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
-    }
-}
-
-publishing {
-    repositories {
-        maven {
-            name = "github"
-            setUrl("https://maven.pkg.github.com/mParticle/crossplatform-sdk-tests")
-            credentials {
-                username = System.getenv("githubUsername")
-                password = System.getenv("githubToken")
-            }
-        }
     }
 }

--- a/testing/build.gradle.kts
+++ b/testing/build.gradle.kts
@@ -1,19 +1,17 @@
-import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 import org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.XCFramework
-import java.lang.System.getProperty
 
 plugins {
     id("com.android.library")
     kotlin("multiplatform")
     kotlin("plugin.serialization")
     kotlin("native.cocoapods")
-    id("maven-publish")
 }
+apply(from = "../.scripts/maven.gradle")
 
 kotlin {
     android {
-        publishLibraryVariants("debug")
+        publishLibraryVariants("release")
         mavenPublication {
             artifactId = "testing"
         }
@@ -97,26 +95,4 @@ android {
 }
 dependencies {
     implementation("androidx.lifecycle:lifecycle-common:2.2.0")
-}
-
-publishing {
-    repositories {
-        maven {
-            name = "github"
-            setUrl("https://maven.pkg.github.com/mParticle/crossplatform-sdk-tests")
-            credentials {
-                username = System.getenv("githubUsername")
-                password = System.getenv("githubToken")
-            }
-        }
-    }
-    afterEvaluate {
-        publications {
-            try {
-                named<MavenPublication>("androidDebug") {
-                    artifactId = project.name
-                }
-            } catch (e: java.lang.Exception) {}
-        }
-    }
 }


### PR DESCRIPTION
## Summary
- configure a release job for maven central via Sonatype
- set packageId to `com.mparticle.internal` to avoid mixing with customer-facing artifacts

example Gradle dependency:
```
implementation("com.mparticle.internal:api:1.0.0")
implementation("com.mparticle.internal:models:1.0.0")
implementation("com.mparticle.internal:testing:1.0.0")
```

## Testing Plan
- test release built and closed in Sonatype (passed Maven Central checks)

## Master Issue
- Closes https://go.mparticle.com/work/SQDSDKS-4135
