### PR TITLE
ci: fix Sonatype release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,6 @@ jobs:
       - name: "Checkout"
         uses: actions/checkout@v2
         with:
-          ref: main
           submodules: recursive
       - name: "Install JDK 11"
         uses: actions/setup-java@v2

--- a/.scripts/maven-metadata.gradle
+++ b/.scripts/maven-metadata.gradle
@@ -1,0 +1,29 @@
+project.ext.pomConfig = {
+    licenses {
+        license {
+            name "The Apache Software License, Version 2.0"
+            url "http://www.apache.org/licenses/LICENSE-2.0.txt"
+            distribution "repo"
+        }
+    }
+    developers {
+        developer {
+            id "mParticle"
+            name "mParticle Inc."
+            organization "mParticle"
+            organizationUrl "https://www.mparticle.com"
+        }
+    }
+
+    scm {
+        url "scm:git:https://github.com/mparticle/crossplatform-sdk-tests"
+    }
+}
+
+project.ext.configureMavenCentralMetadata = { pom ->
+    def root = asNode()
+    root.appendNode('name', project.name)
+    root.appendNode('description', project.name)
+    root.appendNode('url', 'https://github.com/mParticle/crossplatform-sdk-tests')
+    root.children().last() + pomConfig
+}

--- a/.scripts/maven.gradle
+++ b/.scripts/maven.gradle
@@ -1,5 +1,7 @@
 apply plugin: "maven-publish"
 apply plugin: "signing"
+apply from: project.rootProject.file('.scripts/maven-metadata.gradle')
+
 
 publishing {
     publications {
@@ -43,6 +45,10 @@ publishing {
                 }
             }
         }
+
+        task stubJavadoc(type: Jar) {
+            classifier = 'javadoc'
+        }
     }
     repositories {
         maven {
@@ -68,9 +74,18 @@ publishing {
 signing {
     def signingKey = System.getenv("mavenSigningKeyId")
     def signingPassword = System.getenv("mavenSigningKeyPassword")
-    gradle.taskGraph.whenReady {
-        required = it.hasTask("publishReleasePublicationToMavenRepository")
+    if (signingKey != null && signingPassword != null) {
+        useInMemoryPgpKeys(signingKey, signingPassword)
+        sign(publishing.publications)
     }
-    useInMemoryPgpKeys(signingKey, signingPassword)
-    sign(publishing.publications["release"])
+}
+
+afterEvaluate {
+    publishing {
+        // Rename artifacts for backward compatibility
+        publications.all {
+            pom.withXml(configureMavenCentralMetadata)
+            artifact stubJavadoc
+        }
+    }
 }


### PR DESCRIPTION
## Summary
There was a problem with the signing keys and which task we were using to perform our Sonatype/Maven Central release, this fixes the problem

## Testing Plan
- performed release, passed Sonatype validation

## Master Issue
Closes [https://go.mparticle.com/work/](https://go.mparticle.com/work/SQDSDKS-4135