### PR TITLE
feat: publish iOS XCFramework files to Github

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   semantic-release:
-    name: "Semantic Release"
+    name: "Semantic Release & Generate Cocoapods artifacts"
     runs-on: macos-latest
     env:
       GITHUB_TOKEN: ${{ secrets.MP_SEMANTIC_RELEASE_BOT }}
@@ -23,6 +23,14 @@ jobs:
         with:
           fetch-depth: 0
           ref: main
+          submodules: recursive
+      - name: "Install JDK 11"
+        uses: actions/setup-java@v2
+        with:
+          distribution: "zulu"
+          java-version: "11"
+      - name: Install Cocoapods
+        run: sudo gem install cocoapods; sudo gem install cocoapods-generate
       - name: "Import GPG Key"
         uses: crazy-max/ghaction-import-gpg@v4
         with:
@@ -54,7 +62,6 @@ jobs:
         if: ${{ github.event.inputs.dryRun == 'false' }}
         run: |
           git push origin main
-
   sonatype-release:
     name: "Sonatype (Maven Central) Release"
     needs: semantic-release

--- a/.scripts/release.sh
+++ b/.scripts/release.sh
@@ -9,6 +9,8 @@ sed -i '.bak' "s/\"com.mparticle:api:.*\"/\"com.mparticle:api:$1\"/g" README.md
 sed -i '.bak' "s/\"com.mparticle:models:.*\"/\"com.mparticle:models:$1\"/g" README.md
 sed -i '.bak' "s/\"com.mparticle:testing:.*\"/\"com.mparticle:testing:$1\"/g" README.md
 
+sed -i '.bak' "s/\"version\": \".*\"/\"version\": \"$1\"/g" mParticle_Internal.podspec.json
+sed -i '.bak' "s/\"tag\": \".*\"/\"tag\": \"$1\"/g" mParticle_Internal.podspec.json
 #commit the version bump, tag, and push to private and public
 git add gradle.properties
 git add README.md

--- a/Tests/build.gradle.kts
+++ b/Tests/build.gradle.kts
@@ -1,4 +1,6 @@
 import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
+import org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.XCFramework
 
 plugins {
     id("com.android.library")
@@ -8,25 +10,16 @@ plugins {
 }
 
 kotlin {
-    val iOSTarget = if (System.getenv("SDK_NAME")
-            ?.startsWith("iphoneos") == true
-    ) presets.getByName("iosArm64") else presets.getByName("iosX64")
-
     android {
         publishLibraryVariants("debug")
     }
-    val onPhone = System.getenv("SDK_NAME")?.startsWith("iphoneos") ?: false
-    if (onPhone) {
-        iosArm64("ios") {
-            binaries.framework(listOf(org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType.DEBUG))
-
-        }
-    } else {
-        iosX64("ios") {
-            binaries.framework(listOf(org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType.DEBUG))
-
+    val xcFramework = XCFramework()
+    ios {
+        binaries.framework(listOf(NativeBuildType.RELEASE)) {
+            xcFramework.add(this)
         }
     }
+
     cocoapods {
         framework {
             summary = "Cross Platform Testing"
@@ -95,9 +88,9 @@ val installTestPods by tasks.creating(Exec::class.java) {
 
 
 val runIos by tasks.creating(Exec::class.java) {
-    val linkDebugFrameworkIos = tasks.findByName("linkDebugFrameworkIos")
-    dependsOn("linkDebugFrameworkIos")
-    linkDebugFrameworkIos?.dependsOn(installTestPods)
+    val linkReleaseFrameworkIos = tasks.findByName("linkReleaseFrameworkIosX64")
+    dependsOn(linkReleaseFrameworkIos)
+    linkReleaseFrameworkIos?.dependsOn(installTestPods)
     installTestPods.dependsOn("podImport")
     description = "Builds the iOS application bundle using Xcode."
     workingDir = project.file("helpers/XCodeTest")

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -20,18 +20,9 @@ kotlin {
         }
     }
     val xcFramework = XCFramework()
-    val onPhone = System.getenv("SDK_NAME")?.startsWith("iphoneos") ?: false
-    if (onPhone) {
-        iosArm64("ios") {
-            binaries.framework(listOf(NativeBuildType.DEBUG)) {
-                xcFramework.add(this)
-            }
-        }
-    } else {
-        iosX64("ios") {
-            binaries.framework(listOf(NativeBuildType.DEBUG)) {
-                xcFramework.add(this)
-            }
+    ios {
+        binaries.framework(listOf(NativeBuildType.RELEASE)) {
+            xcFramework.add(this)
         }
     }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,6 +15,15 @@ subprojects {
             tasks.register("publishAndroid") { dependsOn("publishAndroidDebugPublicationToMavenLocal") }
         }
     }
+
+    afterEvaluate {
+        val copyXCFramework = tasks.register<Copy>("copyXCFramework") {
+            from("build/cocoapods/publish/release")
+            into("$rootDir/frameworks")
+        }
+
+        tasks.findByName("podPublishReleaseXCFramework")?.finalizedBy(copyXCFramework)
+    }
 }
 
 val appleSDKTempDirPath = "${project.rootDir.absolutePath}/.sdks/apple-testing"

--- a/mParticle_Internal.podspec.json
+++ b/mParticle_Internal.podspec.json
@@ -1,0 +1,51 @@
+{
+  "name": "mParticle-Cross-Platform",
+  "version": "1.1.0",
+  "summary": "mParticle Internal Tools generated using Kotlin Multiplatform",
+  "description": "A collection on internal crossplatform tools and packages",
+  "homepage": "https://www.mparticle.com",
+  "license": {
+    "type": "Apache 2.0",
+    "file": "LICENSE"
+  },
+  "authors": {
+    "mParticle": "support@mparticle.com"
+  },
+  "source": {
+    "git": "https://github.com/mParticle/crossplatform-sdk-tests.git",
+    "tag": "1.1.0"
+  },
+  "default_subspecs": "Testing",
+  "subspecs": [
+    {
+      "name": "Api",
+      "vendored_frameworks": [
+        "frameworks/mParticle_Api.xcframework"
+      ]
+    },
+    {
+      "name": "Mocking",
+      "vendored_frameworks": [
+        "frameworks/mParticle_mocking.xcframework"
+      ]
+    },
+    {
+      "name": "Models",
+      "vendored_frameworks": [
+        "frameworks/mParticle_Models.xcframework"
+      ]
+    },
+    {
+      "name": "Testing",
+      "vendored_frameworks": [
+        "frameworks/mParticle_testing.xcframework"
+      ]
+    },
+    {
+      "name": "Tests",
+      "vendored_frameworks": [
+        "frameworks/mParticle_Multiplatform_Tests.xcframework"
+      ]
+    }
+  ]
+}

--- a/models/build.gradle.kts
+++ b/models/build.gradle.kts
@@ -24,19 +24,9 @@ kotlin {
             artifactId = project.name
         }
     }
-    val onPhone = System.getenv("SDK_NAME")?.startsWith("iphoneos") ?: false
-    if (onPhone) {
-        iosArm64("ios") {
-            binaries.framework(listOf(NativeBuildType.DEBUG)) {
-                xcFramework.add(this)
-            }
-
-        }
-    } else {
-        iosX64("ios") {
-            binaries.framework(listOf(NativeBuildType.DEBUG)) {
-                xcFramework.add(this)
-            }
+    ios {
+        binaries.framework(listOf(NativeBuildType.RELEASE)) {
+            xcFramework.add(this)
         }
     }
 

--- a/release.config.js
+++ b/release.config.js
@@ -35,14 +35,14 @@ module.exports = {
     [
       "@semantic-release/exec",
       {
-        prepareCmd: "sh ./.scripts/release.sh ${nextRelease.version}",
+        prepareCmd: "sh ./.scripts/release.sh ${nextRelease.version}; ./gradlew podPublishReleaseXCFramework",
       },
     ],
     ["@semantic-release/github"],
     [
       "@semantic-release/git",
       {
-        assets: ["CHANGELOG.md", "gradle.properties", "README.md"],
+        assets: ["CHANGELOG.md", "gradle.properties", "README.md", "frameworks", "mParticle_Internal.podspec.json"],
         message:
           "chore(release): ${nextRelease.version} \n\n${nextRelease.notes}",
       },

--- a/testing/build.gradle.kts
+++ b/testing/build.gradle.kts
@@ -17,25 +17,17 @@ kotlin {
         }
     }
     val xcFramework = XCFramework()
-    val onPhone = System.getenv("SDK_NAME")?.startsWith("iphoneos") ?: false
-    if (onPhone) {
-        iosArm64("ios") {
-            binaries.framework(listOf(NativeBuildType.DEBUG)) {
-                xcFramework.add(this)
-            }
-        }
-    } else {
-        iosX64("ios") {
-            binaries.framework(listOf(NativeBuildType.DEBUG)) {
-                xcFramework.add(this)
-            }
+    ios {
+        binaries.framework(listOf(NativeBuildType.RELEASE)) {
+            xcFramework.add(this)
         }
     }
+
     cocoapods {
         framework {
             summary = "Cross Platform Testing"
             homepage = "."
-            baseName = "mParticle_testing"
+            baseName = "mParticle_Testing"
             ios.deploymentTarget = "14.3"
         }
         pod("mParticle-Apple-SDK/mParticle", path = project.file("../.sdks/apple-testing"))


### PR DESCRIPTION
## Summary
Publish iOS xcframeworks for `api`, `models`, `testing` and `Tests` to a Github. Provide `.podspec` file so these can be consumed via Cocoapods. When we run the release task, as part of the semantic release job, we will 

1) update the version number for the `.podspec` file
2) build the xcframework files for each module
3) copy them to the `frameworks` folder
4) add these changes to the version commit

To consume these published frameworks, an ios project can point it's Podfile at this repo. For example:

```
target 'Some Project' do
  # Comment the next line if you don't want to use dynamic frameworks
  use_frameworks!

  # Pods for tester (iOS)
    pod 'mParticle-Cross-Platform/Api', :git => 'https://github.com/mParticle/crossplatform-sdk-tests.git'
    pod 'mParticle-Cross-Platform/Models', :git => 'https://github.com/mParticle/crossplatform-sdk-tests.git'
    pod 'mParticle-Cross-Platform/Testing', :git => 'https://github.com/mParticle/crossplatform-sdk-tests.git'
    pod 'mParticle-Cross-Platform/Tests', :git => 'https://github.com/mParticle/crossplatform-sdk-tests.git'
end
```

Will add all 4 packages.


## Testing Plan
- performed a test release and was able to consume these artifacts from a test branch 

## Master Issue
- Closes https://go.mparticle.com/work/SQDSDKS-4156