### PR TITLE
fix: iOS tests and use latest Xcode version

### DIFF
--- a/.github/workflows/cross-platform-tests.yml
+++ b/.github/workflows/cross-platform-tests.yml
@@ -39,7 +39,7 @@ jobs:
     if: always() && !failure()
     needs: pr-checks
     timeout-minutes: 20
-    runs-on: macos-latest
+    runs-on: macos-12
     steps:
       - name: Checkout Branch
         uses: actions/checkout@v3
@@ -73,7 +73,7 @@ jobs:
   ios-tests:
     name: "IOS Test"
     if: always() && !failure()
-    runs-on: macOS-latest
+    runs-on: macos-12
     needs: pr-checks
     timeout-minutes: 60
     steps:
@@ -95,6 +95,8 @@ jobs:
           java-version: "11"
       - name: Install Cocoapods
         run: sudo gem install cocoapods; sudo gem install cocoapods-generate
+      - name: Choose Xcode version
+        run: sudo xcode-select -s /Applications/Xcode_14.1.app/Contents/Developer
       - name: Run iOS cross platform tests
         run: ./gradlew runIos
       - name: Archive Test Results

--- a/.github/workflows/cross-platform-tests.yml
+++ b/.github/workflows/cross-platform-tests.yml
@@ -57,6 +57,7 @@ jobs:
         with:
           distribution: "zulu"
           java-version: "11"
+          cache: "gradle"
       - name: Install Cocoapods
         run: sudo gem install cocoapods; sudo gem install cocoapods-generate
       - name: Run Instrumented Tests
@@ -93,10 +94,11 @@ jobs:
         with:
           distribution: "zulu"
           java-version: "11"
+          cache: "gradle"
       - name: Install Cocoapods
         run: sudo gem install cocoapods; sudo gem install cocoapods-generate
       - name: Choose Xcode version
-        run: sudo xcode-select -s /Applications/Xcode_14.1.app/Contents/Developer
+        run: xcode-select -p; sudo xcode-select -s /Applications/Xcode_14.1.app/Contents/Developer; xcode-select -p
       - name: Run iOS cross platform tests
         run: ./gradlew runIos
       - name: Archive Test Results

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,7 @@ jobs:
         with:
           distribution: "zulu"
           java-version: "11"
+          cache: "gradle"
       - name: Install Cocoapods
         run: sudo gem install cocoapods; sudo gem install cocoapods-generate
       - name: "Import GPG Key"
@@ -84,6 +85,7 @@ jobs:
         with:
           distribution: "zulu"
           java-version: "11"
+          cache: "gradle"
       - name: Install Cocoapods
         run: sudo gem install cocoapods; sudo gem install cocoapods-generate
       - name: "Publish Android To Sonatype"

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 build
 .idea
 .gradle
-
+local.properties
 
 # iOS Temp SDK
 .sdks/apple-testing

--- a/Tests/build.gradle.kts
+++ b/Tests/build.gradle.kts
@@ -101,7 +101,7 @@ val runIos by tasks.creating(Exec::class.java) {
         "-scheme", "XCodeTestUITests",
         "-workspace", "XCodeTest.xcworkspace",
         "-configuration", "Debug",
-        "-destination", "platform=iOS Simulator,name=iPhone 11,OS=latest",
+        "-destination", "platform=iOS Simulator,name=iPhone 14,OS=latest",
         "test")
 }
 

--- a/testing/src/iosMain/kotlin/com/mparticle/testing/FailureLatch.kt
+++ b/testing/src/iosMain/kotlin/com/mparticle/testing/FailureLatch.kt
@@ -50,7 +50,7 @@ actual class FailureLatch actual constructor(val description: String, count: Int
     }
 
     actual fun await() {
-        await(5L)
+        await(10L)
     }
 
     actual fun await(timeout: Long) {


### PR DESCRIPTION
## Summary
- Explicitly use latest available version of Xcode 14
- Change simulator to iPhone 14 (installed by default with Xcode 14 on all systems)
- Change runner to macos-12
- Change FailureLatch timeout from 5 to 10 seconds
- Add local.properties file to .gitignore so it doesn’t accidentally get checked in
- Add gradle caching

## Testing Plan
Confirmed working now on my local machine. We'll see if the runner changes work when this CI runs.

## Reference Issue
- Closes https://go.mparticle.com/work/SQDSDKS-4718