### PR TITLE
fix: number parsing error in android tests

### DIFF
--- a/Tests/CommonTests/identity/MPUserTests.kt
+++ b/Tests/CommonTests/identity/MPUserTests.kt
@@ -108,13 +108,13 @@ class MPUserTests: BaseStartedTest() {
             incrementUserAttribute("foo", 3)
 
             android_test_hack()
-            getUserAttributes()["foo"] mustEqual 4L
+            getUserAttributes()["foo"] mustEqual 4
 
 
             //test negative increment
             incrementUserAttribute("foo", -2)
             android_test_hack()
-            getUserAttributes()["foo"] mustEqual 2L
+            getUserAttributes()["foo"] mustEqual 2
 
             //test remove incremented attribute
             removeUserAttribute("foo")
@@ -160,17 +160,17 @@ class MPUserTests: BaseStartedTest() {
 
             android_test_hack()
             getUserAttributes().size mustEqual  1
-            getUserAttributes()["foo"] mustEqual 10L
+            getUserAttributes()["foo"] mustEqual 10
             incrementUserAttribute("foo", 37L)
 
             android_test_hack()
-            getUserAttributes()["foo"] mustEqual 47L
+            getUserAttributes()["foo"] mustEqual 47
 
 
             //test negative increment
             incrementUserAttribute("foo", -21L)
             android_test_hack()
-            getUserAttributes()["foo"] mustEqual 26L
+            getUserAttributes()["foo"] mustEqual 26
 
             //test remove incremented attribute
             removeUserAttribute("foo")


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Fixed number parsing error in `MPUserTests.kt` class

 ## Testing Plan
 - [ x] Was this tested locally? If not, explain why.


 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6420
