### PR TITLE
fix:  iOS framework naming related Kotlin Multiplatform projects

### DIFF
--- a/models/build.gradle.kts
+++ b/models/build.gradle.kts
@@ -34,7 +34,9 @@ kotlin {
     cocoapods {
         summary = "MParticle SDK Server Models"
         homepage = "."
-        frameworkName = "mParticle-Models"
+        framework {
+            baseName = "mParticle-Models"
+        }
         ios.deploymentTarget= "14.3"
     }
     sourceSets {


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Update iOS framework naming in Kotlin Multiplatform project due to Kotlin version upgrade

 ## Testing Plan
 - Tested with local build

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6592
