### PR TITLE
feat: Update Android Gradle plugin to 8.1.0

### DIFF
--- a/.scripts/maven.gradle
+++ b/.scripts/maven.gradle
@@ -48,7 +48,7 @@ publishing {
         }
 
         task stubJavadoc(type: Jar) {
-            classifier = 'javadoc'
+            archiveClassifier = 'javadoc'
         }
     }
     repositories {

--- a/Tests/build.gradle.kts
+++ b/Tests/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 kotlin {
-    android {
+    androidTarget {
         publishLibraryVariants("release")
     }
     val xcFramework = XCFramework()
@@ -67,18 +67,25 @@ kotlin {
 }
 
 android {
-    compileSdk = 31
+    namespace = "com.mparticle.tests"
+    compileSdk = 33
     sourceSets["main"].manifest.srcFile("helpers/AndroidManifest.xml")
     sourceSets["androidTest"].java.srcDirs("CommonTests")
 
     defaultConfig {
         minSdk= 14
-        targetSdk = 31
+        targetSdk = 33
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
+    }
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+    kotlinOptions {
+        jvmTarget = "1.8"
     }
 }
 

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 apply(from = "../.scripts/maven.gradle")
 
 kotlin {
-    android {
+    androidTarget {
         publishLibraryVariants("release")
         mavenPublication {
             artifactId = project.name
@@ -58,7 +58,7 @@ kotlin {
 }
 
 android {
-    namespace = "testing"
+    namespace = "com.mparticle.api"
     compileSdk = 33
     sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
 
@@ -72,6 +72,13 @@ android {
         targetCompatibility = JavaVersion.VERSION_1_8
     }
 }
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+}
+
 dependencies {
 //    implementation("androidx.lifecycle:lifecycle-common:2.2.0")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 import org.gradle.internal.impldep.org.apache.commons.io.FileUtils.copyDirectory
+import org.gradle.api.publish.maven.plugins.MavenPublishPlugin
 
 allprojects {
     repositories {
@@ -30,13 +31,12 @@ subprojects {
 val appleSDKTempDirPath = "${project.rootDir.absolutePath}/.sdks/apple-testing"
 
 if (File(appleSDKTempDirPath).exists()) {
-    project.exec {
-        commandLine = "rm -rf $appleSDKTempDirPath".split(" ")
-    }
+    File(appleSDKTempDirPath).deleteRecursively()
 }
 
 project.exec {
-    commandLine = "cp -r ${project.rootDir.absolutePath}/.sdks/apple $appleSDKTempDirPath".split(" ")
+    commandLine = listOf("cp", "-r", "${project.rootDir.absolutePath}/.sdks/apple", appleSDKTempDirPath)
+    isIgnoreExitValue = false
 }
 
 val addTestingHeadersToAppleSDK by tasks.creating {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,4 @@
 kotlin.code.style=official
-kotlin.mpp.enableGranularSourceSetsMetadata=true
-kotlin.native.enableDependencyPropagation=false
-kotlin.mpp.enableCompatibilityMetadataVariant=true
 kotlin.mpp.enableCInteropCommonization=true
 android.useAndroidX=true
 org.gradle.jvmargs=-Xmx5120m

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/mocking/build.gradle.kts
+++ b/mocking/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 apply(from = "../.scripts/maven.gradle")
 
 kotlin {
-    android {
+    androidTarget {
         publishLibraryVariants("release")
         mavenPublication {
             artifactId = "mocking"
@@ -64,11 +64,12 @@ kotlin {
 }
 
 android {
-    compileSdk = 31
+    namespace = "com.mparticle.mocking"
+    compileSdk = 33
     sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
     defaultConfig {
         minSdk = 14
-        targetSdk = 31
+        targetSdk = 33
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
     compileOptions {
@@ -76,6 +77,13 @@ android {
         targetCompatibility = JavaVersion.VERSION_1_8
     }
 }
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+}
+
 dependencies {
     implementation("androidx.lifecycle:lifecycle-common:2.5.0")
 }

--- a/models/build.gradle.kts
+++ b/models/build.gradle.kts
@@ -18,7 +18,7 @@ repositories {
 val xcFramework = XCFramework()
 
 kotlin {
-    android {
+    androidTarget {
         publishLibraryVariants("release")
         mavenPublication {
             artifactId = project.name
@@ -63,5 +63,11 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
+    }
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+    kotlinOptions {
+        jvmTarget = "1.8"
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,8 +2,8 @@ rootProject.name = "sdk-multiplatform-test"
 include("api", "mocking", "models", "testing", "Tests")//, "braze-kit")
 includeBuild(".sdks/android") {
     dependencySubstitution {
-        substitute(module("group:android-core")).with(project(":android-core"))
-        substitute(module("com.mparticle:android-core:+")).with(project(":android-core"))
+        substitute(module("group:android-core")).using(project(":android-core"))
+        substitute(module("com.mparticle:android-core:+")).using(project(":android-core"))
     }
 }
 pluginManagement {
@@ -13,15 +13,15 @@ pluginManagement {
         mavenCentral()
     }
     plugins {
-        id("com.android.library") version("7.3.1")
-        kotlin("multiplatform") version ("1.9.0")
-        kotlin("plugin.serialization") version ("1.6.21")
-        kotlin("native.cocoapods") version ("1.6.21")
+        id("com.android.library") version("8.1.0")
+        kotlin("multiplatform") version ("1.9.20")
+        kotlin("plugin.serialization") version ("1.9.20")
+        kotlin("native.cocoapods") version ("1.9.20")
     }
     resolutionStrategy {
         eachPlugin {
             if (requested.id.namespace == "com.android" || requested.id.name == "kotlin-android-extensions") {
-                useModule("com.android.tools.build:gradle:7.3.1")
+                useModule("com.android.tools.build:gradle:8.1.0")
             }
         }
     }

--- a/testing/build.gradle.kts
+++ b/testing/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 apply(from = "../.scripts/maven.gradle")
 
 kotlin {
-    android {
+    androidTarget {
         publishLibraryVariants("release")
         mavenPublication {
             artifactId = "testing"
@@ -78,6 +78,13 @@ android {
         targetCompatibility = JavaVersion.VERSION_1_8
     }
 }
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+}
+
 dependencies {
     implementation("androidx.lifecycle:lifecycle-common:2.5.0")
 }


### PR DESCRIPTION
## Background
- To stay consistent with other platforms and the core SDK, we’re updating the Android build tools.
Using the same tooling versions helps keep builds reliable, compatible, and consistent across the SDKs.

## What Has Changed
- Updated the Android Gradle Plugin to version 8.1.0
- Aligned Android build tooling with the core SDK and other platform SDKs

## Screenshots/Video
- {Include any screenshots or video demonstrating the new feature or fix, if applicable}

## Checklist
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Additional Notes
- {Any additional information or context relevant to this PR}

## Reference Issue (For employees only. Ignore if you are an outside contributor)
- Closes [Ticket](https://go/j/SDKE-71)
